### PR TITLE
improvement of file descriptor cache controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ If you want to support this project and help us to develop projects like this 10
 ## Quick start
 
 1. Download precompiled version:
-   * [Linux AMD64](https://github.com/xssnick/tonutils-storage/releases/download/v0.6.2/tonutils-storage-linux-amd64)
-   * [Linux ARM64](https://github.com/xssnick/tonutils-storage/releases/download/v0.6.2/tonutils-storage-linux-arm64)
-   * [Windows x64](https://github.com/xssnick/tonutils-storage/releases/download/v0.6.2/tonutils-storage-x64.exe)
-   * [Mac Intel](https://github.com/xssnick/tonutils-storage/releases/download/v0.6.2/tonutils-storage-mac-amd64)
-   * [Mac Apple Silicon](https://github.com/xssnick/tonutils-storage/releases/download/v0.6.2/tonutils-storage-mac-arm64)
+   * [Linux AMD64](https://github.com/xssnick/tonutils-storage/releases/download/v0.6.3/tonutils-storage-linux-amd64)
+   * [Linux ARM64](https://github.com/xssnick/tonutils-storage/releases/download/v0.6.3/tonutils-storage-linux-arm64)
+   * [Windows x64](https://github.com/xssnick/tonutils-storage/releases/download/v0.6.3/tonutils-storage-x64.exe)
+   * [Mac Intel](https://github.com/xssnick/tonutils-storage/releases/download/v0.6.3/tonutils-storage-mac-amd64)
+   * [Mac Apple Silicon](https://github.com/xssnick/tonutils-storage/releases/download/v0.6.3/tonutils-storage-mac-arm64)
 2. Run
 `./tonutils-storage`
 3. Try `download 85d0998dcf325b6fee4f529d4dcf66fb253fc39c59687c82a0ef7fc96fed4c9f`

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/xssnick/tonutils-storage
 go 1.19
 
 require (
+	github.com/kevinms/leakybucket-go v0.0.0-20200115003610-082473db97ca
 	github.com/pterm/pterm v0.12.59
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/xssnick/tonutils-go v1.9.5
 	github.com/xssnick/tonutils-storage-provider v0.2.1-0.20240417140301-cd9a5cee4f3b
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
 )
 
 require (
@@ -15,7 +17,6 @@ require (
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/gookit/color v1.5.3 // indirect
-	github.com/kevinms/leakybucket-go v0.0.0-20200115003610-082473db97ca // indirect
 	github.com/lithammer/fuzzysearch v1.1.5 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20220328075252-7dd334e3daae // indirect
@@ -23,6 +24,7 @@ require (
 	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
-github.com/xssnick/tonutils-go v1.9.5-0.20240417140218-f5211a727ef0 h1:LS+4RL5V23YdErIyWd6sibJl/+IkcnWvHbfS7vy6i3c=
-github.com/xssnick/tonutils-go v1.9.5-0.20240417140218-f5211a727ef0/go.mod h1:p1l1Bxdv9sz6x2jfbuGQUGJn6g5cqg7xsTp8rBHFoJY=
 github.com/xssnick/tonutils-go v1.9.5 h1:kyjWcSEBQeCyXsIMYhdMWIV5coNQZ/89pCriqBXOayM=
 github.com/xssnick/tonutils-go v1.9.5/go.mod h1:p1l1Bxdv9sz6x2jfbuGQUGJn6g5cqg7xsTp8rBHFoJY=
 github.com/xssnick/tonutils-storage-provider v0.2.1-0.20240417140301-cd9a5cee4f3b h1:prvgFJOva8KIbI9lFb6D27etp1+ugt4EODMBXxRUsos=
@@ -87,6 +85,8 @@ golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
+golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -3,110 +3,147 @@ package storage
 import (
 	"io"
 	"os"
-	"runtime"
-	"sort"
 	"sync"
-	"time"
+	"sync/atomic"
 )
-
-type FDesc struct {
-	file   *os.File
-	usedAt time.Time
-	path   string
-
-	mx sync.Mutex
-}
-
-// FSController caches files descriptors to avoid unnecessary open/close of most used files
-type FSController struct {
-	dsc map[string]*FDesc
-	mx  sync.RWMutex
-}
-
-func NewFSController() *FSController {
-	return &FSController{
-		dsc: map[string]*FDesc{},
-	}
-}
 
 const _FDLimit = 800
 
-func (f *FSController) Acquire(path string) (*FDesc, error) {
-	desc := f.acquire(path)
-
-	if desc == nil {
-		f.mx.Lock()
-		desc = f.dsc[path]
-		if desc == nil {
-			if len(f.dsc) >= _FDLimit {
-				for !f.clean() {
-					// retry till we clean something
-					runtime.Gosched()
-				}
-			}
-
-			fl, err := os.Open(path)
-			if err != nil {
-				f.mx.Unlock()
-				return nil, err
-			}
-
-			desc = &FDesc{
-				path:   path,
-				file:   fl,
-				usedAt: time.Now(),
-			}
-			f.dsc[path] = desc
-		}
-		f.mx.Unlock()
-
-		desc.mx.Lock()
-		desc.usedAt = time.Now()
-	}
-	return desc, nil
+type FDesc struct {
+	file *os.File
+	path string
+	mx   sync.Mutex
 }
 
-func (f *FDesc) Free() {
-	f.mx.Unlock()
+func NewFDesc(f *os.File, path string) *FDesc {
+	return &FDesc{
+		file: f,
+		path: path,
+	}
 }
 
 func (f *FDesc) Get() io.ReaderAt {
 	return f.file
 }
 
-func (f *FSController) acquire(path string) *FDesc {
-	f.mx.RLock()
-	desc, ok := f.dsc[path]
-	f.mx.RUnlock()
+// FSController caches files descriptors to avoid unnecessary open/close of most used files
+type FSController struct {
+	dsc     map[string]*FDesc
+	counter atomic.Int32
+	// keep track of the least recently availables file descriptors
+	// they are appended as soon as they are freed, resulting in
+	// oldest file descriptors available to newest file descriptors available
+	availableFdsToClose []*FDesc
+	// limitReached is a conditional variable
+	limitReached sync.Cond
 
-	if ok {
-		desc.mx.Lock()
-		desc.usedAt = time.Now()
-		return desc
+	mx sync.Mutex
+}
+
+func NewFSController() *FSController {
+	fs := new(FSController)
+	fs.dsc = make(map[string]*FDesc)
+	fs.availableFdsToClose = make([]*FDesc, 0)
+	fs.limitReached.L = &fs.mx
+
+	return fs
+}
+
+// Acquire given a path of a file, returns the FDesc associated
+// with that path
+func (fs *FSController) Acquire(path string) (*FDesc, error) {
+	fs.mx.Lock()
+	defer fs.mx.Unlock()
+
+	fd, ok := fs.dsc[path]
+	if !ok {
+		for fs.counter.Load() >= _FDLimit && len(fs.availableFdsToClose) == 0 {
+			fs.limitReached.Wait()
+		}
+
+		// remove one fd from list of available fd to be closed
+		fs.clean()
+
+		// open file
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+
+		// increase counter of files in used
+		fs.counter.Add(1)
+		// we need to check position
+		fd := NewFDesc(f, path)
+		fs.dsc[path] = fd
+		fd.mx.Lock()
+
+		return fd, nil
 	}
+
+	fd.mx.Lock()
+
+	return fd, nil
+}
+
+// Free unlocks a file descriptor given its path
+func (fs *FSController) Free(fd *FDesc) {
+	fs.mx.Lock()
+	defer fs.mx.Unlock()
+
+	fd.mx.Unlock()
+	// add to most recently available file descriptors
+	fs.availableFdsToClose = append(fs.availableFdsToClose, fd)
+	if fs.counter.Load() >= _FDLimit {
+		fs.limitReached.Signal()
+	}
+}
+
+// Get a file descriptor reader given its path
+func (fs *FSController) Get(path string) io.ReaderAt {
+	fd, ok := fs.dsc[path]
+	if !ok {
+		return nil
+	}
+
+	return fd.file
+}
+
+// Release given its path release a file descriptor removing it from cache
+// and decreasing the counter of it
+func (fs *FSController) Release(path string) error {
+	fs.mx.Lock()
+	defer fs.mx.Unlock()
+
+	dsc, ok := fs.dsc[path]
+	if !ok {
+		return nil
+	}
+
+	dsc.mx.Unlock()
+	fs.counter.Add(-1)
+
+	delete(fs.dsc, path)
+	fs.limitReached.Signal()
+
 	return nil
 }
 
-// clean the oldest and currently not used file
-func (f *FSController) clean() bool {
-	list := make([]*FDesc, 0, len(f.dsc))
-	for _, desc := range f.dsc {
-		list = append(list, desc)
+// clean returns true if there's any "available" file descriptor that could be released
+// closing it and removing it from cache. False otherwise.
+// clean is called inside acquire which already called Lock
+func (fs *FSController) clean() {
+	if len(fs.availableFdsToClose) == 0 {
+		return
 	}
 
-	now := time.Now()
-	sort.Slice(list, func(i, j int) bool {
-		return now.Sub(list[i].usedAt) > now.Sub(list[j].usedAt)
-	})
+	// retrieve oldest available file descriptor
+	// which mutex was already unlocked
+	fd := fs.availableFdsToClose[0]
+	_ = fd.file.Close()
+	// remove from availables Fds
+	fs.availableFdsToClose = fs.availableFdsToClose[1:]
 
-	for _, desc := range list {
-		if desc.mx.TryLock() {
-			// it is not used now, so we can close it
-			_ = desc.file.Close()
-			delete(f.dsc, desc.path)
-			desc.mx.Unlock()
-			return true
-		}
-	}
-	return false
+	// decrease counter of used fds
+	fs.counter.Add(-1)
+	delete(fs.dsc, fd.path)
 }

--- a/storage/fs_test.go
+++ b/storage/fs_test.go
@@ -1,0 +1,95 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type testCaseAcquire struct {
+	name  string
+	paths []string
+}
+
+func TestAcquire(t *testing.T) {
+	tcs := genTestCasesAcquire()
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			defer cleanTmpFiles(tc.paths)
+			err := testAcquire(tc.paths)
+			if err != nil {
+				t.Fatal(fmt.Sprintf("error acquiring error: %s", err.Error()))
+			}
+		})
+	}
+}
+
+func BenchmarkAcquire(b *testing.B) {
+	paths := createTmpFiles(2000)
+	defer cleanTmpFiles(paths)
+	for i := 0; i < b.N; i++ {
+		testAcquire(paths)
+	}
+}
+
+func testAcquire(paths []string) error {
+	fs := NewFSController()
+	// acquire all the fd in tc.paths
+	eg := new(errgroup.Group)
+	for i, p := range paths {
+		i, p := i, p
+		fmt.Println("acquiring path", p)
+		eg.Go(func() error {
+			fd, err := fs.Acquire(p)
+			if i > _FDLimit-3 {
+				fs.Free(fd)
+			}
+
+			return err
+		})
+	}
+
+	return eg.Wait()
+}
+
+func genTestCasesAcquire() []testCaseAcquire {
+	return []testCaseAcquire{
+		{
+			name:  "acquiring 3 file descriptors",
+			paths: createTmpFiles(3),
+		},
+		{
+			name:  "acquiring 797 file descriptors",
+			paths: createTmpFiles(797),
+		},
+		{
+			name:  "acquiring _FDLimit file descriptors",
+			paths: createTmpFiles(_FDLimit),
+		},
+		{
+			name:  "acquiring 2000 file descriptors",
+			paths: createTmpFiles(2000),
+		},
+	}
+}
+
+func createTmpFiles(n int) []string {
+	paths := make([]string, n)
+	for i := 0; i < n; i++ {
+		f, _ := os.CreateTemp("", "dump_")
+		p := f.Name()
+		f.Close()
+		paths[i] = p
+	}
+
+	return paths
+}
+
+func cleanTmpFiles(paths []string) {
+	// removing temporary files from system
+	for _, p := range paths {
+		os.Remove(p)
+	}
+}

--- a/storage/fs_test.go
+++ b/storage/fs_test.go
@@ -40,7 +40,6 @@ func testAcquire(paths []string) error {
 	eg := new(errgroup.Group)
 	for i, p := range paths {
 		i, p := i, p
-		fmt.Println("acquiring path", p)
 		eg.Go(func() error {
 			fd, err := fs.Acquire(p)
 			if i > _FDLimit-3 {

--- a/storage/torrent.go
+++ b/storage/torrent.go
@@ -5,14 +5,15 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"fmt"
-	"github.com/xssnick/tonutils-go/adnl/overlay"
-	"github.com/xssnick/tonutils-go/tl"
-	"github.com/xssnick/tonutils-go/tvm/cell"
 	"io"
 	"math/bits"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/xssnick/tonutils-go/adnl/overlay"
+	"github.com/xssnick/tonutils-go/tl"
+	"github.com/xssnick/tonutils-go/tvm/cell"
 )
 
 type FileIndex struct {
@@ -423,7 +424,7 @@ func (t *Torrent) getPieceInternal(id uint32, verify bool) (*Piece, error) {
 				if err != nil {
 					return err
 				}
-				defer fd.Free()
+				defer fs.Free(fd)
 
 				n, err := fd.Get().ReadAt(block[offset:], from)
 				if err != nil && err != io.EOF {


### PR DESCRIPTION
The current implementation of FSController in `storage/fs.go` could be improved in the following way:

1. Replace `TryLock` mechanism with [sync.Cond](https://pkg.go.dev/sync#Cond)
2. Using an slice as a FIFO that keeps track of the file descriptors that were **Freed**. Taking into account that the first appended is the oldest one, that will be the first to be **cleaned**. This will remove the necessity of sorting in the clean process.
3. Adding tests to check validity of these changes in order to detect possible deadlocks, and benchmarks tests to see if these changes actually improved previous implementation.

**Benchmarks on previous version**

```
 /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkAcquire$ github.com/xssnick/tonutils-storage/storage

goos: linux
goarch: amd64
pkg: github.com/xssnick/tonutils-storage/storage
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
=== RUN   BenchmarkAcquire
BenchmarkAcquire
BenchmarkAcquire-8             5         271481025 ns/op         8723393 B/op      19535 allocs/op
PASS
ok      github.com/xssnick/tonutils-storage/storage     4.367s
```

**Benchmarks on new implementation**

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkAcquire$ github.com/xssnick/tonutils-storage/storage

goos: linux
goarch: amd64
pkg: github.com/xssnick/tonutils-storage/storage
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
=== RUN   BenchmarkAcquire
BenchmarkAcquire
BenchmarkAcquire-8            31          42850579 ns/op          587318 B/op      13247 allocs/op
PASS
ok      github.com/xssnick/tonutils-storage/storage     4.397s
```

**Benchmark overview**

|Version| Iterations | Nanosecond / op | Bytes / op |  Allocations / op |
|----------|--------------|------------------------|---------------|-----------------------|
| Old| 5 | 271481025 ns/op | 8723393 B/op | 19535 allocs/ op |
| New | 32 | 42850579 ns/op | 587318 B/op | 13247 allocs/op |