### PR TITLE
add public api to connect avoiding DHT to known peer directly

### DIFF
--- a/storage/server.go
+++ b/storage/server.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/xssnick/tonutils-go/adnl"
+	"github.com/xssnick/tonutils-go/adnl/address"
 	"github.com/xssnick/tonutils-go/adnl/dht"
 	"github.com/xssnick/tonutils-go/adnl/overlay"
 	"github.com/xssnick/tonutils-go/adnl/rldp"
@@ -586,7 +587,7 @@ func (s *Server) nodeConnector(adnlID []byte, t *Torrent, node *overlay.Node, at
 	}
 
 	scaleCtx, stopScale := context.WithTimeout(t.globalCtx, 120*time.Second)
-	stNode, err := s.connectToNode(scaleCtx, t, adnlID, node)
+	stNode, err := s.connectToNode(scaleCtx, t, adnlID, node, nil, nil)
 	stopScale()
 	if err != nil {
 		onFail()
@@ -602,19 +603,30 @@ func (s *Server) nodeConnector(adnlID []byte, t *Torrent, node *overlay.Node, at
 
 	Logger("[STORAGE] ADDED PEER", hex.EncodeToString(adnlID), "FOR", hex.EncodeToString(t.BagID))
 }
+func (s *Server) ConnectToNode(ctx context.Context, t *Torrent, node *overlay.Node, addrList *address.List, nodeKey ed25519.PublicKey) error {
+	adnlID, err := tl.Hash(adnl.PublicKeyED25519{Key: nodeKey})
+	if err != nil {
+		return fmt.Errorf("failed build adnl from node key: %w", err)
+	}
+	Logger("[STORAGE] CONNECTING WITH BOOTSTRAP", hex.EncodeToString(adnlID), adnlID, "FOR", hex.EncodeToString(t.BagID))
+	_, err = s.connectToNode(ctx, t, adnlID, node, addrList, nodeKey)
+	return err
+}
 
-func (s *Server) connectToNode(ctx context.Context, t *Torrent, adnlID []byte, node *overlay.Node) (*storagePeer, error) {
+func (s *Server) connectToNode(ctx context.Context, t *Torrent, adnlID []byte, node *overlay.Node, addrs *address.List, keyN ed25519.PublicKey) (*storagePeer, error) {
 	peer := s.GetPeerIfActive(adnlID)
 	if peer == nil {
 		start := time.Now()
-		lcCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
-		addrs, keyN, err := s.dht.FindAddresses(lcCtx, adnlID)
-		cancel()
-		if err != nil {
-			Logger("[STORAGE] NOT FOUND NODE ADDR OF", hex.EncodeToString(adnlID), "FOR", hex.EncodeToString(t.BagID), "ERR", err.Error())
-			return nil, fmt.Errorf("failed to find node address: %w", err)
+		if addrs == nil && keyN == nil {
+			lcCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+			var err error
+			addrs, keyN, err = s.dht.FindAddresses(lcCtx, adnlID)
+			cancel()
+			if err != nil {
+				Logger("[STORAGE] NOT FOUND NODE ADDR OF", hex.EncodeToString(adnlID), "FOR", hex.EncodeToString(t.BagID), "ERR", err.Error())
+				return nil, fmt.Errorf("failed to find node address: %w", err)
+			}
 		}
-
 		Logger("[STORAGE] ADDR FOR NODE ", hex.EncodeToString(adnlID), "FOUND", addrs.Addresses[0].IP.String(), "FOR", hex.EncodeToString(t.BagID), "ELAPSED", time.Since(start).Seconds())
 
 		addr := addrs.Addresses[0].IP.String() + ":" + fmt.Sprint(addrs.Addresses[0].Port)


### PR DESCRIPTION
To avoid searching storage peers with DHT, it can significantly speed up downloads on newly created bags