### PR TITLE
fix issue with messed order of torrent.ListFiles sometimes

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -280,9 +280,9 @@ func (t *Torrent) ListFiles() ([]string, error) {
 		return nil, err
 	}
 
-	files := make([]string, 0, len(t.filesIndex))
-	for s := range t.filesIndex {
-		files = append(files, s)
+	files := make([]string, len(t.filesIndex), len(t.filesIndex))
+	for s, idx := range t.filesIndex {
+		files[idx] = s
 	}
 	return files, nil
 }


### PR DESCRIPTION
Sometimes althrough filesIndex values are fine file1->0, file2->1 iteration is called staring with second element, which is file2->1 (might be due to hashing / concurrency), as a result file order become messed, that's crucial for pagination