### PR TITLE
force re-establish connection if peer not responding for all bags

### DIFF
--- a/storage/conn.go
+++ b/storage/conn.go
@@ -12,16 +12,33 @@ type PeerConnection struct {
 	adnl adnl.Peer
 
 	mx         sync.RWMutex
+	failedBags map[string]bool
 	usedByBags map[string]*storagePeer
 }
 
+func (c *PeerConnection) FailedFor(peer *storagePeer, failed bool) {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+	if failed {
+		c.failedBags[string(peer.torrent.BagID)] = true
+	} else {
+		delete(c.failedBags, string(peer.torrent.BagID))
+	}
+
+}
 func (c *PeerConnection) CloseFor(peer *storagePeer) {
 	c.mx.Lock()
 	defer c.mx.Unlock()
 
 	delete(c.usedByBags, string(peer.torrent.BagID))
 	Logger("[STORAGE_PEER] CLOSING", hex.EncodeToString(c.adnl.GetID()), "FOR", hex.EncodeToString(peer.torrent.BagID), "LEFT USAGES", len(c.usedByBags))
-
+	for bagID, otherBagPeer := range c.usedByBags {
+		_, hasFailsForBag := c.failedBags[bagID]
+		if hasFailsForBag {
+			delete(c.usedByBags, string(bagID))
+			Logger("[STORAGE_PEER] CLOSING", hex.EncodeToString(otherBagPeer.nodeId), "FOR", hex.EncodeToString([]byte(bagID)), "DUE TO FAILURES")
+		}
+	}
 	if len(c.usedByBags) == 0 {
 		Logger("[STORAGE_PEER] DISCONNECTING, NO MORE USAGES FOR", hex.EncodeToString(c.adnl.GetID()))
 		c.adnl.Close()

--- a/storage/server.go
+++ b/storage/server.go
@@ -167,6 +167,7 @@ func (s *Server) bootstrapPeer(client adnl.Peer) *PeerConnection {
 		rldp:       rl,
 		adnl:       client,
 		usedByBags: map[string]*storagePeer{},
+		failedBags: map[string]bool{},
 	}
 	s.bootstrapped[hex.EncodeToString(client.GetID())] = p
 


### PR DESCRIPTION
In case if multiple bags were served by peer it is not close the connection (https://github.com/xssnick/tonutils-storage/blob/master/storage/conn.go#L25) and on reconnect it fetches "active" peer from bootstrapped, but actually it is not active as it could fail a lot (due to broken channel on server side after restart, or other reasons).

This PR verifies if peer has more failures for other bags and closes the connection if all were failed