### PR TITLE
Fix removal wait and use downloads path

### DIFF
--- a/db/storage.go
+++ b/db/storage.go
@@ -137,6 +137,7 @@ func (s *Storage) RemoveTorrent(t *storage.Torrent, withFiles bool) error {
 	s.mx.Unlock()
 
 	t.Stop()
+	t.Wait()
 
 	b := &leveldb.Batch{}
 	b.Delete(append([]byte("bags:"), t.BagID...))

--- a/storage/download.go
+++ b/storage/download.go
@@ -258,7 +258,9 @@ func (t *Torrent) startDownload(report func(Event)) error {
 	ctx, stop = context.WithCancel(t.globalCtx)
 	t.stopDownload = stop
 
+	t.opWg.Add(1)
 	go func() {
+		defer t.opWg.Done()
 		defer func() {
 			if stop != nil {
 				stop()


### PR DESCRIPTION
## Summary
- wait for torrent goroutines to finish before removing files
- use config's download path in CLI and API
- allow API server to set download root
- start/verify goroutines tracked with WaitGroup

## Testing
- `go test ./...` *(fails: connection to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687614c7f6508320b23c56b7bdc3e466